### PR TITLE
fix color string creation

### DIFF
--- a/text.js
+++ b/text.js
@@ -15,7 +15,7 @@ function makeColorString(rgb) {
       return "255"
     }
     return (x|0).toString(16)
-  }, "1.0").join("")
+  }).join(",") + ", 1.0)";
 }
 
 function createText(gl, str, options) {


### PR DESCRIPTION
Creating the color string is wrong -- doesn't yield the right RGBA(x,x,x,x) format. This fixes that.